### PR TITLE
Writing to extended XYZ format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ More than 2 ML_AB files can be combined at once, e.g.
 mlff merge ML_AB1 ML_AB2 ML_AB3 ML_AB4 ML_AB_NEW
 ```
 
+Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files.
+
+```bash
+mlff write-extxyz ML_AB ML_AB.xyz
+```
+
 ### Python API
 
 More functionality is available through the Python API.
@@ -70,4 +76,18 @@ ab1 = MLAB.from_file("ML_AB1")
 ab2 = MLAB.from_file("ML_AB2")
 
 new_ab = ab1 + ab2
+```
+
+#### Writing to extxyz
+
+MLAB objects can be written to the extxyz format using the `write_extxyz` method.
+
+```python
+from pymlff import MLAB
+
+# load an ML_AB file
+ab = MLAB.from_file("ML_AB")
+
+# write an extxyz file
+ab.write_extxyz("ML_AB.xyz")
 ```

--- a/src/pymlff/cli.py
+++ b/src/pymlff/cli.py
@@ -33,3 +33,19 @@ def merge(inputs, output):
             sys.exit()
 
     new_ml_ab.write_file(output)
+
+
+@cli.command()
+@click.argument("input", type=click.Path(exists=True))
+@click.argument("output", type=click.Path(exists=False))
+def write_extxyz(input, output):
+    """Convert an ML_AB file to extended xyz format."""
+    from pymlff import MLAB
+
+    try:
+        ml_ab = MLAB.from_file(input)
+    except ValueError:
+        click.echo(f"ERROR: Could not read ML_AB file: {input}")
+        sys.exit()
+
+    ml_ab.write_extxyz(output)

--- a/src/pymlff/core.py
+++ b/src/pymlff/core.py
@@ -293,3 +293,16 @@ class MLAB:
         """
         with open(filename, "w") as f:
             f.write(self.to_string())
+
+    def write_extxyz(self, filename):
+        """
+        Write MLAB object to an extended xyz file.
+
+        Parameters
+        ----------
+        filename
+            A filename.
+        """
+        from pymlff.io import ml_ab_to_extxyz
+
+        ml_ab_to_extxyz(self, filename)


### PR DESCRIPTION
- New functionality to write to the extended XYZ format

Example python API usage:
```python
from pymlff import MLAB

# load an ML_AB file
ab = MLAB.from_file("ML_AB")

# write to an .xyz file
ab.write_extxyz("ML_AB.xyz")
```

Example cli usage:

```
mlff write-extyxz ML_AB ML_AB.xyz
```

- Can be useful for other programs which read in configurations in the XYZ format such as Nequip/Allegro
- Can be read into ase:

Example:
```python
from ase.io import read

atoms = read(ML_AB.xyz)
```
