### PR TITLE
Stress units

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ mlff merge ML_AB1 ML_AB2 ML_AB3 ML_AB4 ML_AB_NEW
 Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files. The last argument is the units to use for converting the VASP kbar units. Valid units are eV/A^3 and kbar.
 
 ```bash
-mlff write-extxyz ML_AB ML_AB.xyz eV/A^3
+# Convert ML_AB to extxyz
+mlff write-extxyz ML_AB ML_AB.xyz
+
+# Convert ML_AB to extxyz and convert the units of stress from kbar to eV/A^3 (applies a negative sign)
+mlff write-extxyz ML_AB ML_AB.xyz --stress_units=eV/A^3
 ```
 
 ### Python API

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ More than 2 ML_AB files can be combined at once, e.g.
 mlff merge ML_AB1 ML_AB2 ML_AB3 ML_AB4 ML_AB_NEW
 ```
 
-Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files.
+Pymlff also includes a command line utility for converting ML_AB files to extended xyz (extxyz) files. The last argument is the units to use for converting the VASP kbar units. Valid units are eV/A^3 and kbar.
 
 ```bash
-mlff write-extxyz ML_AB ML_AB.xyz
+mlff write-extxyz ML_AB ML_AB.xyz eV/A^3
 ```
 
 ### Python API
@@ -89,5 +89,5 @@ from pymlff import MLAB
 ab = MLAB.from_file("ML_AB")
 
 # write an extxyz file
-ab.write_extxyz("ML_AB.xyz")
+ab.write_extxyz("ML_AB.xyz", "eV/A^3")
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Pymlff also includes a command line utility for converting ML_AB files to extend
 mlff write-extxyz ML_AB ML_AB.xyz
 
 # Convert ML_AB to extxyz and convert the units of stress from kbar to eV/A^3 (applies a negative sign)
-mlff write-extxyz ML_AB ML_AB.xyz --stress_units=eV/A^3
+mlff write-extxyz ML_AB ML_AB.xyz --stress-unit=eV/A^3
 ```
 
 ### Python API

--- a/src/pymlff/cli.py
+++ b/src/pymlff/cli.py
@@ -38,9 +38,10 @@ def merge(inputs, output):
 @cli.command()
 @click.argument("input", type=click.Path(exists=True))
 @click.argument("output", type=click.Path(exists=False))
-@click.argument("stress_unit", type=click.Choice(["kbar", "eV/A^3"]))
+@click.option("--stress_unit", default=None, required=False)
 def write_extxyz(input, output, stress_unit):
     """Convert an ML_AB file to extended xyz format.
+
 
     STRESS_UNIT is the unit that the stress tensor is converted to.
     It can be either 'kbar' or 'eV/A^3'.

--- a/src/pymlff/cli.py
+++ b/src/pymlff/cli.py
@@ -38,8 +38,14 @@ def merge(inputs, output):
 @cli.command()
 @click.argument("input", type=click.Path(exists=True))
 @click.argument("output", type=click.Path(exists=False))
-def write_extxyz(input, output):
-    """Convert an ML_AB file to extended xyz format."""
+@click.argument("stress_unit", type=click.Choice(["kbar", "eV/A^3"]))
+def write_extxyz(input, output, stress_unit):
+    """Convert an ML_AB file to extended xyz format.
+
+    STRESS_UNIT is the unit that the stress tensor is converted to.
+    It can be either 'kbar' or 'eV/A^3'.
+    We assume the stress tensor is in kbar in the ML_AB file.
+    """
     from pymlff import MLAB
 
     try:
@@ -48,4 +54,4 @@ def write_extxyz(input, output):
         click.echo(f"ERROR: Could not read ML_AB file: {input}")
         sys.exit()
 
-    ml_ab.write_extxyz(output)
+    ml_ab.write_extxyz(output, stress_unit=stress_unit)

--- a/src/pymlff/cli.py
+++ b/src/pymlff/cli.py
@@ -38,7 +38,7 @@ def merge(inputs, output):
 @cli.command()
 @click.argument("input", type=click.Path(exists=True))
 @click.argument("output", type=click.Path(exists=False))
-@click.option("--stress_unit", default=None, required=False)
+@click.option("--stress-unit", default=None, required=False)
 def write_extxyz(input, output, stress_unit):
     """Convert an ML_AB file to extended xyz format.
 

--- a/src/pymlff/core.py
+++ b/src/pymlff/core.py
@@ -294,7 +294,7 @@ class MLAB:
         with open(filename, "w") as f:
             f.write(self.to_string())
 
-    def write_extxyz(self, filename):
+    def write_extxyz(self, filename, stress_unit):
         """
         Write MLAB object to an extended xyz file.
 
@@ -302,7 +302,10 @@ class MLAB:
         ----------
         filename
             A filename.
+        stress_unit
+            Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
+            If 'ev/A^3', the stress is converted from kbar to eV/A^3.
         """
         from pymlff.io import ml_ab_to_extxyz
 
-        ml_ab_to_extxyz(self, filename)
+        ml_ab_to_extxyz(self, filename, stress_unit)

--- a/src/pymlff/core.py
+++ b/src/pymlff/core.py
@@ -265,7 +265,7 @@ class MLAB:
             if el not in new_basis_set:
                 new_basis_set[el] = []
 
-            for (config_idx, atom_idx) in el_basis:
+            for config_idx, atom_idx in el_basis:
                 new_basis_set[el].append((config_idx + last_idx, atom_idx))
 
         return MLAB(
@@ -294,7 +294,7 @@ class MLAB:
         with open(filename, "w") as f:
             f.write(self.to_string())
 
-    def write_extxyz(self, filename, stress_unit):
+    def write_extxyz(self, filename, stress_unit=None):
         """
         Write MLAB object to an extended xyz file.
 
@@ -303,8 +303,9 @@ class MLAB:
         filename
             A filename.
         stress_unit
-            Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
-            If 'ev/A^3', the stress is converted from kbar to eV/A^3.
+            Unit of stress to convert to. VASP units are kbar. Default is None which leaves the units alone.
+            If 'ev/A^3', the stress is converted from kbar to eV/A^3 (with a negative sign convention assumed).
+
         """
         from pymlff.io import ml_ab_to_extxyz
 

--- a/src/pymlff/io.py
+++ b/src/pymlff/io.py
@@ -304,7 +304,7 @@ def _three_fmt(obj, prefix=""):
     return f"\n{prefix}".join([" ".join(x) for x in _grouper(obj, 3)])
 
 
-def ml_ab_to_extxyz(ml_ab, filename, stress_unit='ev/A^3'):
+def ml_ab_to_extxyz(ml_ab, filename, stress_unit='eV/A^3'):
     """
     Convert an MLAB object to an extended XYZ string representation.
     Parameters
@@ -314,12 +314,12 @@ def ml_ab_to_extxyz(ml_ab, filename, stress_unit='ev/A^3'):
     filename
         Path to an extended XYZ file.
     stress_unit
-        Unit of stress. VASP units are kbar. Default is 'ev/A^3'.
+        Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
         If 'ev/A^3', the stress is converted from kbar to eV/A^3.
     """
     if stress_unit == 'kbar':
         stress_unit = 1
-    elif stress_unit == 'ev/A^3':
+    elif stress_unit == 'eV/A^3':
         stress_unit = _KBAR_TO_EV_Acub
     with open(filename, 'w') as f:
         for i, conf in enumerate(ml_ab.configurations):

--- a/src/pymlff/io.py
+++ b/src/pymlff/io.py
@@ -222,20 +222,20 @@ def _parse_config(config):
     natom_types = int(config[7])
     natoms = int(config[11])
     atom_types_numbers = {
-        x.split()[0]: int(x.split()[1]) for x in config[15: 15 + natom_types]
+        x.split()[0]: int(x.split()[1]) for x in config[15 : 15 + natom_types]
     }
     ctifor = float(config[18 + natom_types])
     lattice = [
-        list(map(float, x.split())) for x in config[22 + natom_types: 25 + natom_types]
+        list(map(float, x.split())) for x in config[22 + natom_types : 25 + natom_types]
     ]
     coords = [
         list(map(float, x.split()))
-        for x in config[28 + natom_types: 28 + natom_types + natoms]
+        for x in config[28 + natom_types : 28 + natom_types + natoms]
     ]
     total_energy = float(config[31 + natom_types + natoms])
     forces = [
         list(map(float, x.split()))
-        for x in config[35 + natom_types + natoms: 35 + natom_types + natoms * 2]
+        for x in config[35 + natom_types + natoms : 35 + natom_types + natoms * 2]
     ]
     stress_diagonal = list(map(float, config[40 + natom_types + natoms * 2].split()))
     stress_off_diagonal = list(
@@ -259,15 +259,15 @@ def _parse_header(header):
     version = header[0]
     natom_types = int(header[8])
     nlines = int(np.ceil(natom_types / 3))
-    atom_types = " ".join(header[12: 12 + nlines]).split()
+    atom_types = " ".join(header[12 : 12 + nlines]).split()
     reference_energy = list(
-        map(float, " ".join(header[23 + nlines: 23 + nlines * 2]).split())
+        map(float, " ".join(header[23 + nlines : 23 + nlines * 2]).split())
     )
     atomic_mass = list(
-        map(float, " ".join(header[26 + nlines * 2: 26 + nlines * 3]).split())
+        map(float, " ".join(header[26 + nlines * 2 : 26 + nlines * 3]).split())
     )
     num_basis = list(
-        map(int, " ".join(header[29 + nlines * 3: 29 + nlines * 4]).split())
+        map(int, " ".join(header[29 + nlines * 3 : 29 + nlines * 4]).split())
     )
     basis_set = {}
 
@@ -275,7 +275,7 @@ def _parse_header(header):
         c = sum(num_basis[:i]) + 3 * i
         basis_set[atom_types[i]] = [
             list(map(int, x.split()))
-            for x in header[32 + nlines * 4 + c: 32 + nlines * 4 + nbasis + c]
+            for x in header[32 + nlines * 4 + c : 32 + nlines * 4 + nbasis + c]
         ]
 
     return {
@@ -304,7 +304,7 @@ def _three_fmt(obj, prefix=""):
     return f"\n{prefix}".join([" ".join(x) for x in _grouper(obj, 3)])
 
 
-def ml_ab_to_extxyz(ml_ab, filename, stress_unit='eV/A^3'):
+def ml_ab_to_extxyz(ml_ab, filename, stress_unit=None):
     """
     Convert an MLAB object to an extended XYZ string representation.
     Parameters
@@ -314,24 +314,40 @@ def ml_ab_to_extxyz(ml_ab, filename, stress_unit='eV/A^3'):
     filename
         Path to an extended XYZ file.
     stress_unit
-        Unit of stress to convert to. VASP units are kbar. Default is 'ev/A^3'.
-        If 'ev/A^3', the stress is converted from kbar to eV/A^3.
+        Unit of stress to convert to. VASP units are kbar. Default is None which leaves the units alone.
+        If 'ev/A^3', the stress is converted from kbar to eV/A^3 (with a negative sign convention assumed).
     """
-    if stress_unit == 'kbar':
+    if stress_unit == "kbar" or not stress_unit:
         stress_unit = 1
-    elif stress_unit == 'eV/A^3':
-        stress_unit = _KBAR_TO_EV_Acub
-    with open(filename, 'w') as f:
+    elif stress_unit == "eV/A^3":
+        stress_unit = -1 * _KBAR_TO_EV_Acub
+    else:
+        raise ValueError(f"Unknown stress unit: {stress_unit}")
+    with open(filename, "w") as f:
         for i, conf in enumerate(ml_ab.configurations):
             stress = stress_unit * np.array(
-                [-conf.stress_diagonal[0], -conf.stress_off_diagonal[0], -conf.stress_off_diagonal[2],
-                 -conf.stress_off_diagonal[0], -conf.stress_diagonal[1], -conf.stress_off_diagonal[1],
-                 -conf.stress_off_diagonal[2], -conf.stress_off_diagonal[1], -conf.stress_diagonal[2]])
+                [
+                    conf.stress_diagonal[0],
+                    conf.stress_off_diagonal[0],
+                    conf.stress_off_diagonal[2],
+                    conf.stress_off_diagonal[0],
+                    conf.stress_diagonal[1],
+                    conf.stress_off_diagonal[1],
+                    conf.stress_off_diagonal[2],
+                    conf.stress_off_diagonal[1],
+                    conf.stress_diagonal[2],
+                ]
+            )
             f.write(str(conf.num_atoms) + "\n")
 
-            f.write(_INIT_STR_EXTYXZ.format(conf.total_energy,
-                                            ' '.join(map("{:.16f}".format, stress)),
-                                            ' '.join(map("{:.16f}".format, conf.lattice.flatten()))) + "\n")
+            f.write(
+                _INIT_STR_EXTYXZ.format(
+                    conf.total_energy,
+                    " ".join(map("{:.16f}".format, stress)),
+                    " ".join(map("{:.16f}".format, conf.lattice.flatten())),
+                )
+                + "\n"
+            )
             c = 0
             for el, num in conf.atom_types_numbers.items():
                 for j in range(num):


### PR DESCRIPTION
- Can now specify the units to convert the stress to through the CLI and through the Python API

API example:
```python
from pymlff import MLAB

# Load file
ab = MLAB.from_file("ML_ABN")

# Write xyz file with stress units in kbar
ab = MLAB.write_extxyz("ML_AB_kbar.xyz", "kbar")

# Write xyz file with stress units in eV/A^3
ab = MLAB.write_extxyz("ML_AB_eV.xyz", "eV/A^3")
```

CLI example:
```bash

# Write xyz file with stress units in kbar
mlff ML_ABN ML_ABN_kbar.xyz kbar

# Write xyz file with stress units in eV/A^3
mlff ML_ABN ML_ABN_eV.xyz eV/A^3
```